### PR TITLE
Flexibilitza GrufNoteControls per afegir selectorPresets a part

### DIFF
--- a/static/src/js/components/estacioGrooveBox.jsx
+++ b/static/src/js/components/estacioGrooveBox.jsx
@@ -31,9 +31,10 @@ export const EstacioGrooveBoxUI = ({estacio, setEstacioSelected}) => {
                 <GrufButtonBorder className="col-start-3 row-start-1" style={{width: 100, height: 50}} text="Canvia estació" onClick={() => { setEstacioSelected(undefined) }}/>
 
                 {/* Contenidor de controls: Selector de Patrons, Clear, Presets, Rec */}
-                <fieldset className="modul-border modul-bg flex flex-row justify-between items-center col-start-1 row-start-3 grid justify-between items-center gap-10" style={{width: 400, height:150}}>
-                    <GrufSelectorPatronsGrid className="col-start-1 row-start-1" estacio={estacio} parameterName="pattern" width= "225" />
-                    <GrufNoteControls className="col-start-2 row-start-1 row-span-2" estacio={estacio} width="175px" clearParameter={"pattern"}/>
+                <fieldset className="modul-border modul-bg grid col-start-1 row-start-3 grid gap-10" style={{width: 400, height:150}}>
+                    <GrufSelectorPatronsGrid className="col-start-1 row-start-1" estacio={estacio} parameterName="pattern" width= "260px" />
+                    <GrufNoteControls className="col-start-2 row-start-1 row-span-2" estacio={estacio} selectorPresets = {true} width="100px" clearParameter={"pattern"}/>
+                    <GrufSelectorPresets className="col-start-1 row-start-2" estacio={estacio}/>
                 </fieldset>
 
                 {/* Módul de EQ */}

--- a/static/src/js/components/widgets.jsx
+++ b/static/src/js/components/widgets.jsx
@@ -706,16 +706,26 @@ export const GrufPianoRoll = ({ className, estacio, parameterName, top, left, wi
     )
 };
 
-export const GrufNoteControls = ({ className, estacio, width, clearParameter}) => {
+export const GrufNoteControls = ({ className, estacio, width, clearParameter = "notes", selectorPresets = false }) => {
     const { recordingElementId, toggleRecording } = createRecordingHandler(estacio, clearParameter);
 
     return (
         <fieldset className={className} style={{ width: width }}>
-            <GrufSelectorPresets className="flex flex-auto flex-wrap gap-10 justify-between" estacio={estacio} buttonWidth="58px" />
+            {!selectorPresets && (
+                <GrufSelectorPresets
+                    className="flex flex-auto flex-wrap gap-10 justify-between"
+                    estacio={estacio}
+                    buttonWidth="58px"
+                />
+            )}
             <fieldset className="flex flex-col gap-10">
-                <input id={recordingElementId} type="checkbox" style={{display:"none"}}/>
-                <button style={{padding: '0', minHeight: '58px'}} onMouseDown={(evt)=> estacio.updateParametreEstacio(clearParameter, [])}>Clear</button>
-                <button style={{padding: '0', minHeight: '58px'}} onMouseDown={(evt)=> toggleRecording(evt.target)}>Rec</button>
+                <input id={recordingElementId} type="checkbox" style={{ display: "none" }} />
+                <button style={{ padding: '0', minHeight: '58px' }} onMouseDown={() => estacio.updateParametreEstacio(clearParameter, [])}>
+                    Clear
+                </button>
+                <button style={{ padding: '0', minHeight: '58px' }} onMouseDown={(evt) => toggleRecording(evt.target)}>
+                    Rec
+                </button>
             </fieldset>
         </fieldset>
     );

--- a/static/src/styles/widgets.scss
+++ b/static/src/styles/widgets.scss
@@ -756,6 +756,7 @@
         text-align: center;
         vertical-align: middle;
         cursor: pointer;
+        margin-right: 0.25rem;
 
         &.active {
             border-color: $white;


### PR DESCRIPTION
No sabia com disposar els elements perquè tal i com estava GrufNoteControls pugués encaixar amb el disseny de grooveBox. He fet un invent que no se si és el més adequat. He afegit la prop booleana selectorPreset que en funció d'aquesta renderitzi o no GrufSelectorPresets.  